### PR TITLE
Signal handling to be able to quit from another process, show track title, take mimetype from command line

### DIFF
--- a/cast.py
+++ b/cast.py
@@ -79,12 +79,15 @@ def resolve_name(name, max_depth, args):
 			return
 	else:
 		# remote file
-		with contextlib.closing(urllib2.urlopen(parsed.geturl())) as source:
-			filetype = source.info()["content-type"]
-			url = source.geturl()
-			if filetype in supportedtypes:
-				yield (url, filetype, None, None)
-			return
+                if args.mimetype:
+                        yield (parsed.geturl(), args.mimetype, None, None)
+                        return
+                with contextlib.closing(urllib2.urlopen(parsed.geturl())) as source:
+                        filetype = source.info()["content-type"]
+                        url = source.geturl()
+                        if filetype in supportedtypes:
+                                yield (url, filetype, None, None)
+                        return
 
 	# youtube link or ID
 	youtube_re = re.compile(r"(https?://)?(www\.)?(youtube|youtu|youtube-nocookie)\.(com|be)/(watch\?v=|embed/|v/|.+\?v=)?([^&=%\?]{11})")
@@ -207,6 +210,7 @@ if __name__ == "__main__":
 	parser.add_argument("-p", "--port",      type=int, default=5403,                                       help="port on which to serve content")
 	parser.add_argument("-d", "--device",    type=str, default=None,                                       help="name of cast target")
         parser.add_argument(      "--pid",       type=str, default=None,                                       help="file to write PID to")
+        parser.add_argument(      "--mimetype",  type=str, default=None,                                       help="skip mime type detection for remote content, use provided one")
 	args = parser.parse_args()
 
 	cast(args)

--- a/cast.py
+++ b/cast.py
@@ -186,7 +186,7 @@ def cast(args):
 				# So don't even bother yet.
 				print("Ignoring youtube link")
 			else:
-				cast.play_media(url, filetype)
+				cast.play_media(url, filetype, title=args.title)
 
 			while not controller.is_idle and not stop_signal: #or not yt_controller.is_idle:
 				pass
@@ -211,6 +211,7 @@ if __name__ == "__main__":
 	parser.add_argument("-d", "--device",    type=str, default=None,                                       help="name of cast target")
         parser.add_argument(      "--pid",       type=str, default=None,                                       help="file to write PID to")
         parser.add_argument(      "--mimetype",  type=str, default=None,                                       help="skip mime type detection for remote content, use provided one")
+        parser.add_argument(      "--title",     type=str, default=None,                                       help="on screen title to show")                
 	args = parser.parse_args()
 
 	cast(args)

--- a/pychromecast/controllers/media.py
+++ b/pychromecast/controllers/media.py
@@ -165,21 +165,23 @@ class MediaController(BaseController):
                 'contentId': url,
                 'streamType': stream_type,
                 'contentType': content_type,
-                # 'metadata': {'type': 2,
-                #              'metadataType': 0,
-                #              'title': 'Main title PyChromecast!! :-)',
-                #              'subtitle': "Subtitle"}
+                 'metadata': {'type': 2,
+                              'metadataType': 0,
+                              'title': title,
+                              'subtitle': title}
             },
             MESSAGE_TYPE: TYPE_LOAD,
             'currentTime': current_time,
             'autoplay': autoplay,
-            'customData': {}
+            'customData': {'payload': {}}
         }
 
         if title:
+            # this doesn't seem to do anything?
             msg['customData']['payload']['title'] = title
 
         if thumb:
+            # this doesn't seem to do anything?            
             msg['customData']['payload']['thumb'] = thumb
 
         self.send_message(msg, inc_session_id=True)


### PR DESCRIPTION
I run cast.py on a pi controlled with an X10 remote, so I wanted a way to stop the casting again.

Arguably it should be SIGINT handling or something other than SIGTERM though, as it my version 
wouldn't quit right away, it would move to the next 'item'.

I'd love to be able to show a thumbnail (of the music stream I'm listening to), but I didn't get that working yet.
